### PR TITLE
🗄️ Change: ユーザー認証のためのカラムをuserテーブルに加える

### DIFF
--- a/src/db/drizzle/20250510030042_fancy_shinobi_shaw.sql
+++ b/src/db/drizzle/20250510030042_fancy_shinobi_shaw.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `users` ADD `uid` varchar(128) NOT NULL;--> statement-breakpoint
+ALTER TABLE `users` ADD `provider` enum('google','magic_link') NOT NULL;--> statement-breakpoint
+ALTER TABLE `users` ADD CONSTRAINT `users_uid_unique` UNIQUE(`uid`);

--- a/src/db/drizzle/meta/20250510030042_snapshot.json
+++ b/src/db/drizzle/meta/20250510030042_snapshot.json
@@ -1,0 +1,876 @@
+{
+	"version": "5",
+	"dialect": "mysql",
+	"id": "94f78ec0-209d-42d9-9885-0fc519c2fc60",
+	"prevId": "787f24bf-debf-4c6c-b359-07d1499c85e3",
+	"tables": {
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"img": {
+					"name": "img",
+					"type": "varchar(250)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uid": {
+					"name": "uid",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "enum('google','magic_link')",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"speaker": {
+					"name": "speaker",
+					"type": "enum('en-US-Standard-A','en-US-Standard-B','en-US-Standard-C','en-US-Standard-D','en-US-Standard-E','en-US-Standard-F','en-US-Standard-G','en-US-Standard-H','en-US-Standard-I','en-US-Standard-J')",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false,
+					"default": "'en-US-Standard-H'"
+				},
+				"stripe_customer_id": {
+					"name": "stripe_customer_id",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note_prompt": {
+					"name": "note_prompt",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"users_name_unique": {
+					"name": "users_name_unique",
+					"columns": ["name"]
+				},
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": ["email"]
+				},
+				"users_uid_unique": {
+					"name": "users_uid_unique",
+					"columns": ["uid"]
+				},
+				"users_stripe_customer_id_unique": {
+					"name": "users_stripe_customer_id_unique",
+					"columns": ["stripe_customer_id"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"antonyms": {
+			"name": "antonyms",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_antonyms_word": {
+					"name": "idx_antonyms_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"antonyms_word_id_words_id_fk": {
+					"name": "antonyms_word_id_words_id_fk",
+					"tableFrom": "antonyms",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"antonyms_id": {
+					"name": "antonyms_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"collocations": {
+			"name": "collocations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(200)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_collocations_word": {
+					"name": "idx_collocations_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"collocations_word_id_words_id_fk": {
+					"name": "collocations_word_id_words_id_fk",
+					"tableFrom": "collocations",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"collocations_id": {
+					"name": "collocations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"derivations": {
+			"name": "derivations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(200)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_derivations_word": {
+					"name": "idx_derivations_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"derivations_word_id_words_id_fk": {
+					"name": "derivations_word_id_words_id_fk",
+					"tableFrom": "derivations",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"derivations_id": {
+					"name": "derivations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"examples": {
+			"name": "examples",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(200)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_examples_word_id": {
+					"name": "idx_examples_word_id",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"examples_word_id_words_id_fk": {
+					"name": "examples_word_id_words_id_fk",
+					"tableFrom": "examples",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"examples_id": {
+					"name": "examples_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"phrasal_verbs": {
+			"name": "phrasal_verbs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_phrasal_verbs_word": {
+					"name": "idx_phrasal_verbs_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"phrasal_verbs_word_id_words_id_fk": {
+					"name": "phrasal_verbs_word_id_words_id_fk",
+					"tableFrom": "phrasal_verbs",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"phrasal_verbs_id": {
+					"name": "phrasal_verbs_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"synonyms": {
+			"name": "synonyms",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_synonyms_word": {
+					"name": "idx_synonyms_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"synonyms_word_id_words_id_fk": {
+					"name": "synonyms_word_id_words_id_fk",
+					"tableFrom": "synonyms",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"synonyms_id": {
+					"name": "synonyms_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"types": {
+			"name": "types",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "tinyint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"types_id": {
+					"name": "types_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"types_name_unique": {
+					"name": "types_name_unique",
+					"columns": ["name"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"user_words": {
+			"name": "user_words",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_user_words": {
+					"name": "idx_user_words",
+					"columns": ["user_id", "word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"user_words_user_id_users_id_fk": {
+					"name": "user_words_user_id_users_id_fk",
+					"tableFrom": "user_words",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_words_word_id_words_id_fk": {
+					"name": "user_words_word_id_words_id_fk",
+					"tableFrom": "user_words",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_words_id": {
+					"name": "user_words_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"word_types": {
+			"name": "word_types",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "tinyint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_word_types": {
+					"name": "idx_word_types",
+					"columns": ["word_id", "type_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"word_types_word_id_words_id_fk": {
+					"name": "word_types_word_id_words_id_fk",
+					"tableFrom": "word_types",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"word_types_type_id_types_id_fk": {
+					"name": "word_types_type_id_types_id_fk",
+					"tableFrom": "word_types",
+					"tableTo": "types",
+					"columnsFrom": ["type_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"word_types_id": {
+					"name": "word_types_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"words": {
+			"name": "words",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"word": {
+					"name": "word",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"pronunciation": {
+					"name": "pronunciation",
+					"type": "varchar(200)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"meaning": {
+					"name": "meaning",
+					"type": "varchar(300)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"frequency": {
+					"name": "frequency",
+					"type": "tinyint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"etymology": {
+					"name": "etymology",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"img": {
+					"name": "img",
+					"type": "varchar(250)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"deleted_at": {
+					"name": "deleted_at",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_words_user_word": {
+					"name": "idx_words_user_word",
+					"columns": ["user_id", "word"],
+					"isUnique": false
+				},
+				"idx_words_frequency": {
+					"name": "idx_words_frequency",
+					"columns": ["frequency"],
+					"isUnique": false
+				},
+				"idx_words_word": {
+					"name": "idx_words_word",
+					"columns": ["word"],
+					"isUnique": false
+				},
+				"idx_words_deleted_at": {
+					"name": "idx_words_deleted_at",
+					"columns": ["deleted_at"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"words_user_id_users_id_fk": {
+					"name": "words_user_id_users_id_fk",
+					"tableFrom": "words",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"words_id": {
+					"name": "words_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"tag_words": {
+			"name": "tag_words",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"tag_id": {
+					"name": "tag_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_tag_words": {
+					"name": "idx_tag_words",
+					"columns": ["tag_id", "word_id"],
+					"isUnique": false
+				},
+				"idx_word_tags": {
+					"name": "idx_word_tags",
+					"columns": ["word_id", "tag_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"tag_words_tag_id_tags_id_fk": {
+					"name": "tag_words_tag_id_tags_id_fk",
+					"tableFrom": "tag_words",
+					"tableTo": "tags",
+					"columnsFrom": ["tag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tag_words_word_id_words_id_fk": {
+					"name": "tag_words_word_id_words_id_fk",
+					"tableFrom": "tag_words",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"tag_words_id": {
+					"name": "tag_words_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"idx_tag_words_unique": {
+					"name": "idx_tag_words_unique",
+					"columns": ["tag_id", "word_id"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"tags": {
+			"name": "tags",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"tags_user_id_users_id_fk": {
+					"name": "tags_user_id_users_id_fk",
+					"tableFrom": "tags",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"tags_id": {
+					"name": "tags_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"idx_tags_user_name": {
+					"name": "idx_tags_user_name",
+					"columns": ["user_id", "name"]
+				}
+			},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
 			"when": 1746511538835,
 			"tag": "20250506060538_nice_dreaming_celestial",
 			"breakpoints": true
+		},
+		{
+			"idx": 4,
+			"version": "5",
+			"when": 1746846042026,
+			"tag": "20250510030042_fancy_shinobi_shaw",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/schema/user.ts
+++ b/src/db/schema/user.ts
@@ -5,6 +5,8 @@ export const users = mysqlTable("users", {
 	name: varchar("name", { length: 50 }).notNull().unique(),
 	email: varchar("email", { length: 255 }).notNull().unique(),
 	img: varchar("img", { length: 250 }),
+	uid: varchar("uid", { length: 128 }).notNull().unique(),
+	provider: mysqlEnum("provider", ["google", "magic_link"]).notNull(),
 	speaker: mysqlEnum("speaker", [
 		"en-US-Standard-A",
 		"en-US-Standard-B",


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
firebase認証で以下の認証を行うためuserテーブルにカラムを追加
- provider
- uid

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1]
- [変更点2]
- [変更点3]

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] tableにデータが変更されていることを確認しました。

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->


## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->


## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->

## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->
特記事項があれば記載してください。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユーザー情報に一意な識別子（uid）と認証プロバイダー（google または magic_link）が追加されました。
- **その他**
  - データベーススキーマのスナップショットが更新され、関連テーブルや制約が反映されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->