### PR TITLE
🐞 Fix: user.nameの文字列を最大50文字から20文字に修正

### DIFF
--- a/src/db/drizzle/20250518064836_eager_blackheart.sql
+++ b/src/db/drizzle/20250518064836_eager_blackheart.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` MODIFY COLUMN `name` varchar(20) NOT NULL;

--- a/src/db/drizzle/meta/20250518064836_snapshot.json
+++ b/src/db/drizzle/meta/20250518064836_snapshot.json
@@ -1,0 +1,1062 @@
+{
+	"version": "5",
+	"dialect": "mysql",
+	"id": "92e0c836-6e47-43ca-85ef-f7f9eed17da2",
+	"prevId": "18265b1d-f88d-41b9-a408-55adf3c72ea7",
+	"tables": {
+		"users": {
+			"name": "users",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"email": {
+					"name": "email",
+					"type": "varchar(255)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"img": {
+					"name": "img",
+					"type": "varchar(250)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"uid": {
+					"name": "uid",
+					"type": "varchar(128)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"provider": {
+					"name": "provider",
+					"type": "enum('google','magic_link')",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"users_id": {
+					"name": "users_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"users_name_unique": {
+					"name": "users_name_unique",
+					"columns": ["name"]
+				},
+				"users_email_unique": {
+					"name": "users_email_unique",
+					"columns": ["email"]
+				},
+				"users_uid_unique": {
+					"name": "users_uid_unique",
+					"columns": ["uid"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"antonyms": {
+			"name": "antonyms",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_antonyms_word": {
+					"name": "idx_antonyms_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"antonyms_word_id_words_id_fk": {
+					"name": "antonyms_word_id_words_id_fk",
+					"tableFrom": "antonyms",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"antonyms_id": {
+					"name": "antonyms_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"collocations": {
+			"name": "collocations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(200)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_collocations_word": {
+					"name": "idx_collocations_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"collocations_word_id_words_id_fk": {
+					"name": "collocations_word_id_words_id_fk",
+					"tableFrom": "collocations",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"collocations_id": {
+					"name": "collocations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"deletion_schedules": {
+			"name": "deletion_schedules",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"delete_date": {
+					"name": "delete_date",
+					"type": "date",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"deletion_schedules_word_id_words_id_fk": {
+					"name": "deletion_schedules_word_id_words_id_fk",
+					"tableFrom": "deletion_schedules",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"deletion_schedules_id": {
+					"name": "deletion_schedules_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"deletion_schedules_word_id_unique": {
+					"name": "deletion_schedules_word_id_unique",
+					"columns": ["word_id"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"derivations": {
+			"name": "derivations",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(200)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_derivations_word": {
+					"name": "idx_derivations_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"derivations_word_id_words_id_fk": {
+					"name": "derivations_word_id_words_id_fk",
+					"tableFrom": "derivations",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"derivations_id": {
+					"name": "derivations_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"examples": {
+			"name": "examples",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(200)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_examples_word_id": {
+					"name": "idx_examples_word_id",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"examples_word_id_words_id_fk": {
+					"name": "examples_word_id_words_id_fk",
+					"tableFrom": "examples",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"examples_id": {
+					"name": "examples_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"inputs": {
+			"name": "inputs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_inputs_user_word": {
+					"name": "idx_inputs_user_word",
+					"columns": ["user_id", "word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"inputs_user_id_users_id_fk": {
+					"name": "inputs_user_id_users_id_fk",
+					"tableFrom": "inputs",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"inputs_word_id_words_id_fk": {
+					"name": "inputs_word_id_words_id_fk",
+					"tableFrom": "inputs",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"inputs_id": {
+					"name": "inputs_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"uq_inputs_user_word": {
+					"name": "uq_inputs_user_word",
+					"columns": ["user_id", "word_id"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"phrasal_verbs": {
+			"name": "phrasal_verbs",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_phrasal_verbs_word": {
+					"name": "idx_phrasal_verbs_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"phrasal_verbs_word_id_words_id_fk": {
+					"name": "phrasal_verbs_word_id_words_id_fk",
+					"tableFrom": "phrasal_verbs",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"phrasal_verbs_id": {
+					"name": "phrasal_verbs_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"synonyms": {
+			"name": "synonyms",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_synonyms_word": {
+					"name": "idx_synonyms_word",
+					"columns": ["word_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"synonyms_word_id_words_id_fk": {
+					"name": "synonyms_word_id_words_id_fk",
+					"tableFrom": "synonyms",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"synonyms_id": {
+					"name": "synonyms_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"types": {
+			"name": "types",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "tinyint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"category": {
+					"name": "category",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"description": {
+					"name": "description",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"types_id": {
+					"name": "types_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"types_category_unique": {
+					"name": "types_category_unique",
+					"columns": ["category"]
+				},
+				"types_name_unique": {
+					"name": "types_name_unique",
+					"columns": ["name"]
+				},
+				"types_description_unique": {
+					"name": "types_description_unique",
+					"columns": ["description"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"word_types": {
+			"name": "word_types",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"type_id": {
+					"name": "type_id",
+					"type": "tinyint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_word_types": {
+					"name": "idx_word_types",
+					"columns": ["word_id", "type_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"word_types_word_id_words_id_fk": {
+					"name": "word_types_word_id_words_id_fk",
+					"tableFrom": "word_types",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"word_types_type_id_types_id_fk": {
+					"name": "word_types_type_id_types_id_fk",
+					"tableFrom": "word_types",
+					"tableTo": "types",
+					"columnsFrom": ["type_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"word_types_id": {
+					"name": "word_types_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"words": {
+			"name": "words",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"word": {
+					"name": "word",
+					"type": "varchar(50)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"translation": {
+					"name": "translation",
+					"type": "varchar(100)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"pronunciation": {
+					"name": "pronunciation",
+					"type": "varchar(200)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"meaning": {
+					"name": "meaning",
+					"type": "varchar(300)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"frequency": {
+					"name": "frequency",
+					"type": "tinyint unsigned",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"etymology": {
+					"name": "etymology",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"note": {
+					"name": "note",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				},
+				"img": {
+					"name": "img",
+					"type": "varchar(250)",
+					"primaryKey": false,
+					"notNull": false,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_words_user_word": {
+					"name": "idx_words_user_word",
+					"columns": ["user_id", "word"],
+					"isUnique": false
+				},
+				"idx_words_word": {
+					"name": "idx_words_word",
+					"columns": ["word"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"words_user_id_users_id_fk": {
+					"name": "words_user_id_users_id_fk",
+					"tableFrom": "words",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"words_id": {
+					"name": "words_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {},
+			"checkConstraint": {}
+		},
+		"tag_words": {
+			"name": "tag_words",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"tag_id": {
+					"name": "tag_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"word_id": {
+					"name": "word_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"position": {
+					"name": "position",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {
+				"idx_word_tags": {
+					"name": "idx_word_tags",
+					"columns": ["word_id", "tag_id"],
+					"isUnique": false
+				}
+			},
+			"foreignKeys": {
+				"tag_words_tag_id_tags_id_fk": {
+					"name": "tag_words_tag_id_tags_id_fk",
+					"tableFrom": "tag_words",
+					"tableTo": "tags",
+					"columnsFrom": ["tag_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"tag_words_word_id_words_id_fk": {
+					"name": "tag_words_word_id_words_id_fk",
+					"tableFrom": "tag_words",
+					"tableTo": "words",
+					"columnsFrom": ["word_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"tag_words_id": {
+					"name": "tag_words_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"idx_tag_words_unique": {
+					"name": "idx_tag_words_unique",
+					"columns": ["tag_id", "word_id"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"tags": {
+			"name": "tags",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"name": {
+					"name": "name",
+					"type": "varchar(15)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"tags_user_id_users_id_fk": {
+					"name": "tags_user_id_users_id_fk",
+					"tableFrom": "tags",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"tags_id": {
+					"name": "tags_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"idx_tags_user_name": {
+					"name": "idx_tags_user_name",
+					"columns": ["user_id", "name"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"speakers": {
+			"name": "speakers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "tinyint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"identifier": {
+					"name": "identifier",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"feature": {
+					"name": "feature",
+					"type": "varchar(20)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {},
+			"compositePrimaryKeys": {
+				"speakers_id": {
+					"name": "speakers_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"speakers_identifier_unique": {
+					"name": "speakers_identifier_unique",
+					"columns": ["identifier"]
+				},
+				"speakers_feature_unique": {
+					"name": "speakers_feature_unique",
+					"columns": ["feature"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"user_speakers": {
+			"name": "user_speakers",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"speaker_id": {
+					"name": "speaker_id",
+					"type": "tinyint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"user_speakers_user_id_users_id_fk": {
+					"name": "user_speakers_user_id_users_id_fk",
+					"tableFrom": "user_speakers",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				},
+				"user_speakers_speaker_id_speakers_id_fk": {
+					"name": "user_speakers_speaker_id_speakers_id_fk",
+					"tableFrom": "user_speakers",
+					"tableTo": "speakers",
+					"columnsFrom": ["speaker_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"user_speakers_id": {
+					"name": "user_speakers_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"user_speakers_user_id_unique": {
+					"name": "user_speakers_user_id_unique",
+					"columns": ["user_id"]
+				}
+			},
+			"checkConstraint": {}
+		},
+		"note_prompts": {
+			"name": "note_prompts",
+			"columns": {
+				"id": {
+					"name": "id",
+					"type": "serial",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": true
+				},
+				"user_id": {
+					"name": "user_id",
+					"type": "bigint unsigned",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				},
+				"text": {
+					"name": "text",
+					"type": "varchar(500)",
+					"primaryKey": false,
+					"notNull": true,
+					"autoincrement": false
+				}
+			},
+			"indexes": {},
+			"foreignKeys": {
+				"note_prompts_user_id_users_id_fk": {
+					"name": "note_prompts_user_id_users_id_fk",
+					"tableFrom": "note_prompts",
+					"tableTo": "users",
+					"columnsFrom": ["user_id"],
+					"columnsTo": ["id"],
+					"onDelete": "cascade",
+					"onUpdate": "no action"
+				}
+			},
+			"compositePrimaryKeys": {
+				"note_prompts_id": {
+					"name": "note_prompts_id",
+					"columns": ["id"]
+				}
+			},
+			"uniqueConstraints": {
+				"note_prompts_user_id_unique": {
+					"name": "note_prompts_user_id_unique",
+					"columns": ["user_id"]
+				}
+			},
+			"checkConstraint": {}
+		}
+	},
+	"views": {},
+	"_meta": {
+		"schemas": {},
+		"tables": {},
+		"columns": {}
+	},
+	"internal": {
+		"tables": {},
+		"indexes": {}
+	}
+}

--- a/src/db/drizzle/meta/_journal.json
+++ b/src/db/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
 			"when": 1747479767142,
 			"tag": "20250517110247_good_jackpot",
 			"breakpoints": true
+		},
+		{
+			"idx": 2,
+			"version": "5",
+			"when": 1747550916218,
+			"tag": "20250518064836_eager_blackheart",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/db/schema/user.ts
+++ b/src/db/schema/user.ts
@@ -2,7 +2,7 @@ import { mysqlEnum, mysqlTable, serial, varchar } from "drizzle-orm/mysql-core";
 
 export const users = mysqlTable("users", {
 	id: serial("id").primaryKey(),
-	name: varchar("name", { length: 50 }).notNull().unique(),
+	name: varchar("name", { length: 20 }).notNull().unique(),
 	email: varchar("email", { length: 255 }).notNull().unique(),
 	img: varchar("img", { length: 250 }),
 	uid: varchar("uid", { length: 128 }).notNull().unique(),


### PR DESCRIPTION
## 概要
<!-- このプルリクエストの目的や背景を簡潔に説明してください。 -->
schemaのuser.nameの値が誤って、50文字と書いてあった。最大20文字の制約を全体で決めてあるので直す。

## 変更内容
<!-- 具体的にどのような変更を行ったのかを説明してください。 -->
- [変更点1] schemaのuser.tsを修正
- [変更点2] userテーブルをdirizzle kitでgenerateとmigrateした
- [変更点3]

## チェックリスト
<!-- プルリクエストを提出する前にチェックすべき項目をリストアップしてください。 -->
- [ ] DBが正しく変更されているか？

## 関連するチケット
<!-- 関連するチケットやIssue番号を記載してください。 -->
- Closes #15 

## 参考記事
<!-- 参考にした記事やドキュメントのリンクを記載してください。 -->


## スクリーンショット（必要に応じて）
<!-- UIの変更が含まれる場合、スクリーンショットを追加してください。 -->


## その他
<!-- その他、レビュワーに知っておいてほしいことがあれば記載してください。 -->
特記事項があれば記載してください。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - データベーススキーマのスナップショットが追加され、複数のテーブルとその制約が明確化されました。

- **改善**
  - ユーザー名の最大文字数が50文字から20文字に変更され、必須入力となりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->